### PR TITLE
Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Extra Actions
 This extension adds commonly-used stats and rolls to the top of the Actions tab to save time while playing.
+Originally developed by [Markjan](https://www.fantasygrounds.com/forums/member.php?10744-Markjan) as [PFRPG - Raccourcis Actions](https://www.fantasygrounds.com/forums/showthread.php?40381-Combat-Shortcuts-actions-extension). Available on Forge with automatic updates [here](https://forge.fantasygrounds.com/shop/items/132/view).
 
 # Compatibility and Instructions
 This extension has been tested with [FantasyGrounds Unity](https://www.fantasygrounds.com/home/FantasyGroundsUnity.php) 4.2.2 (2022-06-07).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Extra Actions
+This extension adds commonly-used stats and rolls to the top of the Actions tab to save time while playing.
+
+# Compatibility and Instructions
+This extension has been tested with [FantasyGrounds Unity](https://www.fantasygrounds.com/home/FantasyGroundsUnity.php) 4.2.2 (2022-06-07).
+
+It has been tested with the Pathfinder 1e and D&D 3.5E rulesets.
+
+# Features
+Adds Initiative, Saving Throws, Base Attacks, CMB/CMD, and AC to the Actions tab to speed up play.
+
+# Example Images
+![actions tab shortcuts](https://www.fantasygrounds.com/forums/attachment.php?attachmentid=41106&d=1605367871)

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ It has been tested with the Pathfinder 1e and D&D 3.5E rulesets.
 Adds Initiative, Saving Throws, Base Attacks, CMB/CMD, and AC to the Actions tab to speed up play.
 
 # Example Images
-![actions tab shortcuts](https://www.fantasygrounds.com/forums/attachment.php?attachmentid=41106&d=1605367871)
+![actions tab shortcuts](https://user-images.githubusercontent.com/1916835/184497407-b7364714-776e-405c-8891-b02542b9c9af.png)

--- a/campaign/record_char_actions.xml
+++ b/campaign/record_char_actions.xml
@@ -8,13 +8,16 @@
 <root>
 	<windowclass name="charsheet_actions" merge="join">
 		<sheetdata>
-		
-			<frame_char name="shortcutframe" insertbefore="actionframe">
-				<bounds>15,0,480,65</bounds>
+
+			<frame_char name="shortcutframe">
+				<bounds>15,0,-29,65</bounds>
 			</frame_char>
 			
 			<number_charinit name="initiative" source="initiative.total">
-				<anchored to="shortcutframe" position="insidetopleft" offset="20,25" width="30" height="28" />
+				<anchored to="shortcutframe" width="32" height="28" >
+					<top offset="25" />
+					<left anchor="left" relation="relative" offset="15" />
+				</anchored>
 			</number_charinit>
 			<label_fieldtop>
 				<anchored to="initiative" />
@@ -22,21 +25,32 @@
 			</label_fieldtop>
 
 			<number_charsavefort name="fortitude" source="saves.fortitude.total">
-				<anchored to="shortcutframe" position="insidetopleft" offset="75,25" width="30" height="28" />
+				<anchored to="initiative" width="32" height="28" >
+					<top />
+					<left anchor="right" relation="relative" offset="15" />
+				</anchored>
 			</number_charsavefort>
 			<label_fieldtop>
 				<anchored to="fortitude" />
 				<static textres="fort" />
 			</label_fieldtop>
+
 			<number_charsaveref name="reflex" source="saves.reflex.total">
-				<anchored to="shortcutframe" position="insidetopleft" offset="120,25" width="30" height="28" />
+				<anchored to="initiative" width="32" height="28" >
+					<top />
+					<left anchor="right" relation="relative" offset="15" />
+				</anchored>
 			</number_charsaveref>
 			<label_fieldtop>
 				<anchored to="reflex" />
 				<static textres="ref" />
 			</label_fieldtop>
+
 			<number_charsavewill name="will" source="saves.will.total">
-				<anchored to="shortcutframe" position="insidetopleft" offset="165,25" width="30" height="28" />
+				<anchored to="initiative" width="32" height="28" >
+					<top />
+					<left anchor="right" relation="relative" offset="15" />
+				</anchored>
 			</number_charsavewill>
 			<label_fieldtop>
 				<anchored to="will" />
@@ -44,7 +58,10 @@
 			</label_fieldtop>
 			
 			<number_charmeleetotal name="meleemainattackbonus" source="attackbonus.melee.total">
-				<anchored to="shortcutframe" position="insidetopleft" offset="220,25" width="30" height="28" />
+				<anchored to="initiative" width="32" height="28" >
+					<top />
+					<left anchor="right" relation="relative" offset="15" />
+				</anchored>
 			</number_charmeleetotal>
 			<label_fieldtop>
 				<anchored to="meleemainattackbonus" />
@@ -52,7 +69,10 @@
 			</label_fieldtop>
 			
 			<number_charrangedtotal name="rangedmainattackbonus" source="attackbonus.ranged.total">
-				<anchored to="shortcutframe" position="insidetopleft" offset="265,25" width="30" height="28" />
+				<anchored to="initiative" width="32" height="28" >
+					<top />
+					<left anchor="right" relation="relative" offset="15" />
+				</anchored>
 			</number_charrangedtotal>
 			<label_fieldtop>
 				<anchored to="rangedmainattackbonus" />
@@ -60,7 +80,10 @@
 			</label_fieldtop>	
 					
 			<number_chargrappletotal name="grappleattackbonus" source="attackbonus.grapple.total">
-				<anchored to="shortcutframe" position="insidetopleft" offset="310,25" width="30" height="28" />
+				<anchored to="initiative" width="32" height="28" >
+					<top />
+					<left anchor="right" relation="relative" offset="15" />
+				</anchored>
 			</number_chargrappletotal>
 			<label_fieldtop name="label_cmb">
 				<anchored to="grappleattackbonus" />
@@ -68,7 +91,10 @@
 			</label_fieldtop>
 			
 			<number_charcmd name="cmd" source="ac.totals.cmd">
-				<anchored to="shortcutframe" position="insidetopleft" offset="365,25" width="30" height="28" />
+				<anchored to="initiative" width="32" height="28" >
+					<top />
+					<left anchor="right" relation="relative" offset="15" />
+				</anchored>
 			</number_charcmd>
 			<label_fieldtop name="label_cmd">
 				<anchored to="cmd" />
@@ -79,15 +105,15 @@
 				<anchored to="shortcutframe" position="insidetopright" offset="15,15" width="30" height="28" />
 				<frame name="acicon" />
 			</number_chartotalac>
-			<label_fieldtop name="label_AC">
+			<label_fieldtop name="label_ac">
 				<anchored to="shortcutframe" position="insidetopright" offset="24,34" />
 				<static textres="ac" />
 			</label_fieldtop>
-			
+
 			<frame_char name="actionframe">
 				<bounds>15,65,-25,-5</bounds>
 			</frame_char>
-			
+
 		</sheetdata>
 	</windowclass>
 </root>


### PR DESCRIPTION
1. Allow shortcutframe to resize with window
2. Remove unnecessary insertbefore
3. Use relative positioning of fields (easier to work with in future).
4. Adjust spacing and size of fields. More consistent and doesn't obfuscate the Ranged label.
5. Add README.md to repo.